### PR TITLE
Conditional imports to support operating with `pydantic>2` installed

### DIFF
--- a/prefect_hex/credentials.py
+++ b/prefect_hex/credentials.py
@@ -2,7 +2,12 @@
 
 from httpx import AsyncClient
 from prefect.blocks.core import Block
-from pydantic import Field, SecretStr
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import Field, SecretStr
+else:
+    from pydantic import Field, SecretStr
 
 
 class HexCredentials(Block):

--- a/prefect_hex/models/project.py
+++ b/prefect_hex/models/project.py
@@ -4,7 +4,12 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Extra, Field, HttpUrl
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Extra, Field, HttpUrl
+else:
+    from pydantic import BaseModel, Extra, Field, HttpUrl
 
 
 class ProjectRunStatus(Enum):

--- a/prefect_hex/rest.py
+++ b/prefect_hex/rest.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 
 import httpx
 from prefect import task
-from pydantic import BaseModel
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel
+else:
+    from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from prefect_hex import HexCredentials

--- a/tests/test_rest.py
+++ b/tests/test_rest.py
@@ -2,7 +2,12 @@ from typing import List
 
 import httpx
 import pytest
-from pydantic import BaseModel, Extra
+from pydantic import VERSION as PYDANTIC_VERSION
+
+if PYDANTIC_VERSION.startswith("2."):
+    from pydantic.v1 import BaseModel, Extra
+else:
+    from pydantic import BaseModel, Extra
 
 from prefect_hex import HexCredentials
 from prefect_hex.rest import HTTPMethod, execute_endpoint, serialize_model, strip_kwargs


### PR DESCRIPTION
Following the compatibility work we've done in `prefect`, we also want to apply the
same compatibility changes to all Prefect-maintained collections.  We're following the
convention that Prefect will always use `pydantic<2` idioms, leaning on the
`pydantic.v1` module of `pydantic>2` to aid us in this.  With these changes, we can
operate normally regardless of the installed version.

Until `prefect` fully deprecates `pydantic` versions below 2.0, we'll continue to
maintain that constraint of using only v1 idioms.

This is part of a series of identical PRs for all of our maintained collections.